### PR TITLE
Fix 'no schema with key or ref "http://json-schema.org/draft-07/schema#"'

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -40,20 +40,68 @@ describe('validateDependabot', () => {
 
 | keyword | message | dataPath |
 | ------- | ------- | -------- |
+| maxLength | should NOT be longer than 50 characters | .updates[0]['commit-message'].prefix |
 | required | should have required property 'directory' | .updates[0] |
-| invalid | commit-message.prefix require to be less than 50 characters | .updates[0].commit-message.prefix |
-| invalid | commit-message.prefix-development require to be less than 50 characters | .updates[1].commit-message.prefix-development |
+| required | should have required property 'schedule' | .updates[0] |
+| maxLength | should NOT be longer than 50 characters | .updates[1]['commit-message']['prefix-development'] |
+| required | should have required property 'directory' | .updates[1] |
+| required | should have required property 'schedule' | .updates[1] |
 `,
       errors: [
         {
-          dataPath: '.updates[0]',
-          keyword: 'required',
-          message: "should have required property 'directory'",
-          params: {
-            missingProperty: 'directory'
+          "dataPath": ".updates[0]['commit-message'].prefix",
+          "keyword": "maxLength",
+          "message": "should NOT be longer than 50 characters",
+          "params": {
+            "limit": 50
           },
-          schemaPath: '#/required'
-        }
+          "schemaPath": "#/properties/commit-message/properties/prefix/maxLength",
+        },
+        {
+          "dataPath": ".updates[0]",
+          "keyword": "required",
+          "message": "should have required property 'directory'",
+          "params": {
+            "missingProperty": "directory",
+          },
+          "schemaPath": "#/required",
+        },
+        {
+          "dataPath": ".updates[0]",
+          "keyword": "required",
+          "message": "should have required property 'schedule'",
+          "params": {
+            "missingProperty": "schedule",
+          },
+          "schemaPath": "#/required",
+        },
+        {
+          "dataPath": ".updates[1]['commit-message']['prefix-development']",
+          "keyword": "maxLength",
+          "message": "should NOT be longer than 50 characters",
+          "params": {
+            "limit": 50
+          },
+          "schemaPath": "#/properties/commit-message/properties/prefix-development/maxLength",
+        },
+        {
+          "dataPath": ".updates[1]",
+          "keyword": "required",
+          "message": "should have required property 'directory'",
+          "params": {
+            "missingProperty": "directory",
+          },
+          "schemaPath": "#/required",
+        },
+        {
+          "dataPath": ".updates[1]",
+          "keyword": "required",
+          "message": "should have required property 'schedule'",
+          "params": {
+            "missingProperty": "schedule",
+          },
+          "schemaPath": "#/required",
+        },
       ]
     })
   })

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "ajv": "^4.11.8",
+    "ajv": "^6.12.6",
     "node-fetch": "2.6.7",
     "yaml": "^2.3.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,15 +1253,7 @@ agent-base@^7.0.2, agent-base@^7.1.0:
   dependencies:
     debug "^4.3.4"
 
-ajv@^4.11.8:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
-ajv@^6.12.4:
+ajv@^6.12.4, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3986,13 +3978,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stable-stringify@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz#e06f23128e0bbe342dc996ed5a19e28b57b580e0"
-  integrity sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==
-  dependencies:
-    jsonify "^0.0.1"
-
 json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -4011,11 +3996,6 @@ jsonfile@^4.0.0:
   integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
-  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsx-ast-utils@^3.3.2, jsx-ast-utils@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
This pull request fixes the failure reported in #644. Please see https://github.com/marocchino/validate-dependabot/issues/644#issuecomment-1835407597 for reasoning behind the proposed changes.

This pull request contains the following changes:
- Bump `ajv` version to the latest 6.x version to add support for `draft-07` JSON meta-schema
- Update `ajv` config to return all schema violations at once
- Remove the in-house validation logic
  - It seems like `ajv` errors do include max length violations now
- Update the unit test according to the aforementioned changes