### PR TITLE
:scroll: :recycle: fix the schema download failures due to schama TLS cert error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core'
 import Ajv, {ErrorObject} from 'ajv'
 import YAML from 'yaml'
-import fetch from 'node-fetch'
 import {readFileSync} from 'fs'
+import schema from './schema/dependabot-2.0.json';
 
 async function run(): Promise<void> {
   try {
@@ -41,12 +41,8 @@ export async function validateDependabot(
   const yaml = readFileSync(path, 'utf-8')
   const json = YAML.parse(yaml)
 
-  // load schema
-  const response = await fetch(
-    'https://json.schemastore.org/dependabot-2.0.json'
-  )
-
-  const schema = (await response.json()) as object
+  // running from the dist dir, then we need to load if from there
+  const schema = require('./schema/dependabot-2.0.json');
 
   // validate
   const validate = ajv.compile(schema)


### PR DESCRIPTION
As the dependabot schema download is failing, loading it  from sources to avoid the external dependency download.